### PR TITLE
Untrack settings.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ remote-settings.json
 .github/
 catalog-info.yaml
 plans/
+settings.json
 /.last-cleanup
 jobs/
 daemon/

--- a/pimp/install
+++ b/pimp/install
@@ -30,6 +30,10 @@ install_link "$PIMP_DIR/broot/skins/rasta.hjson" ~/.config/broot/skins/rasta.hjs
 install_link "$PIMP_DIR/micro/settings.json" ~/.config/micro/settings.json
 install_link "$PIMP_DIR/micro/colorschemes/rasta.micro" ~/.config/micro/colorschemes/rasta.micro
 
+if [[ ! -f "$REPO_DIR/settings.json" ]]; then
+  cp "$REPO_DIR/settings.example.json" "$REPO_DIR/settings.json"
+fi
+
 # Make sure pimp hooks exist (they're called by .githooks)
 mkdir -p "$PIMP_DIR/hooks"
 

--- a/settings.example.json
+++ b/settings.example.json
@@ -23,7 +23,7 @@
     ],
     "defaultMode": "dontAsk"
   },
-  "model": "fable",
+  "model": "sonnet",
   "hooks": {},
   "statusLine": {
     "type": "command",


### PR DESCRIPTION
settings.json churns constantly as agents flip model/effortLevel. Untracked and gitignored; settings.example.json added as the committed template.